### PR TITLE
Hitting pages that redirect causes an error

### DIFF
--- a/src/Diggin/Bridge/Guzzle/AutoCharsetEncodingPlugin/AutoCharsetEncodingPlugin.php
+++ b/src/Diggin/Bridge/Guzzle/AutoCharsetEncodingPlugin/AutoCharsetEncodingPlugin.php
@@ -19,7 +19,7 @@ class AutoCharsetEncodingPlugin implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array('request.complete' => 'onRequestComplete');
+        return array('request.complete' => array('onRequestComplete', 255));
     }
 
     /**
@@ -29,7 +29,8 @@ class AutoCharsetEncodingPlugin implements EventSubscriberInterface
     {
         if ($res = $event['request']->getResponse()) {
             $contentType = $res->getHeader('content-type', true);
-            if (!preg_match('#^text/html#i', $contentType)) {
+            $redirect = $res->getHeader('Location');
+            if (!empty($redirect) || !preg_match('#^text/html#i', $contentType)) {
                 return;
             }
             $bodyEntity = $res->getBody(false);


### PR DESCRIPTION
If Guzzle hits a page that throws a redirect, the plugin throws an error. This PR tells the plugin not to analyze pages that are just redirects.
