### PR TITLE
option to define many content types.

### DIFF
--- a/src/Diggin/Bridge/Guzzle/AutoCharsetEncodingPlugin/AutoCharsetEncodingPlugin.php
+++ b/src/Diggin/Bridge/Guzzle/AutoCharsetEncodingPlugin/AutoCharsetEncodingPlugin.php
@@ -14,7 +14,7 @@ class AutoCharsetEncodingPlugin implements EventSubscriberInterface
      */
     protected $charset_front;
     /**
-     * @var array
+     * @var string
      */
     private $contentTypes;
 

--- a/src/Diggin/Bridge/Guzzle/AutoCharsetEncodingPlugin/AutoCharsetEncodingPlugin.php
+++ b/src/Diggin/Bridge/Guzzle/AutoCharsetEncodingPlugin/AutoCharsetEncodingPlugin.php
@@ -1,11 +1,11 @@
 <?php
 namespace Diggin\Bridge\Guzzle\AutoCharsetEncodingPlugin;
 
+use Diggin\Http\Charset\Filter;
+use Diggin\Http\Charset\Front\DocumentConverter;
+use Diggin\Http\Charset\Front\UrlRegex;
 use Guzzle\Common\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Diggin\Http\Charset\Filter;
-use Diggin\Http\Charset\Front\UrlRegex;
-use Diggin\Http\Charset\Front\DocumentConverter;
 
 class AutoCharsetEncodingPlugin implements EventSubscriberInterface
 {
@@ -13,6 +13,17 @@ class AutoCharsetEncodingPlugin implements EventSubscriberInterface
      * @var DocumentConverter
      */
     protected $charset_front;
+    /**
+     * @var array
+     */
+    private $contentTypes;
+
+    /**
+     * @param array $contentTypes
+     */
+    public function __construct($contentTypes = array('text/html')) {
+        $this->contentTypes = '[' . implode('|', $contentTypes) . ']';
+    }
 
     /**
      * {@inheritdoc}
@@ -30,7 +41,7 @@ class AutoCharsetEncodingPlugin implements EventSubscriberInterface
         if ($res = $event['request']->getResponse()) {
             $contentType = $res->getHeader('content-type', true);
             $redirect = $res->getHeader('Location');
-            if (!empty($redirect) || !preg_match('#^text/html#i', $contentType)) {
+            if (!empty($redirect) || !preg_match('#^' . $this->contentTypes . '#i', $contentType)) {
                 return;
             }
             $bodyEntity = $res->getBody(false);

--- a/src/Diggin/Bridge/Guzzle/AutoCharsetEncodingPlugin/AutoCharsetEncodingPlugin.php
+++ b/src/Diggin/Bridge/Guzzle/AutoCharsetEncodingPlugin/AutoCharsetEncodingPlugin.php
@@ -14,15 +14,17 @@ class AutoCharsetEncodingPlugin implements EventSubscriberInterface
      */
     protected $charset_front;
     /**
-     * @var string
+     * @var string[]
      */
-    private $contentTypes;
+    private $contentTypes = array('text/html');
 
     /**
-     * @param array $contentTypes
+     * @param string[] $contentTypes
      */
-    public function __construct($contentTypes = array('text/html')) {
-        $this->contentTypes = '[' . implode('|', $contentTypes) . ']';
+    public function __construct($contentTypes = array()) {
+        if (!empty($contentTypes)) {
+            $this->contentTypes = '[' . implode('|', $contentTypes) . ']';
+        }
     }
 
     /**

--- a/src/Diggin/Bridge/Guzzle/AutoCharsetEncodingPlugin/AutoCharsetEncodingPlugin.php
+++ b/src/Diggin/Bridge/Guzzle/AutoCharsetEncodingPlugin/AutoCharsetEncodingPlugin.php
@@ -16,15 +16,17 @@ class AutoCharsetEncodingPlugin implements EventSubscriberInterface
     /**
      * @var string[]
      */
-    private $contentTypes = array('text/html');
+    private $contentTypes;
 
     /**
      * @param string[] $contentTypes
      */
-    public function __construct($contentTypes = array()) {
-        if (!empty($contentTypes)) {
-            $this->contentTypes = '[' . implode('|', $contentTypes) . ']';
+    public function __construct($contentTypes = array('text/html')) {
+        if (!is_array($contentTypes) || empty($contentTypes)) {
+            throw new \InvalidArgumentException('Invalid content-type');
         }
+
+        $this->contentTypes = '[' . implode('|', $contentTypes) . ']';
     }
 
     /**


### PR DESCRIPTION
Enabled option to developer define wich type of content type should be parsed by auto charset encoding plugin.

The developer can define that defining a array with all the content type.
new AutoCharsetEncodingPlugin(array('text/html', 'application/json'))

Or replace the default value:
new AutoCharsetEncodingPlugin(array('application/json'))

Or use the default content type 'text/html'
new AutoCharsetEncodingPlugin()
